### PR TITLE
Fixing Receiving Multiple Messages

### DIFF
--- a/BottangoNetworkedDriver/src/MainLoop.py
+++ b/BottangoNetworkedDriver/src/MainLoop.py
@@ -31,8 +31,11 @@ def threadedRead(s):
 		# check if there's a command that was recieved in the buffer
 		# new line is the terminating character for a command
 		if '\n' in cmdBuffer:
-			cmdQueue.put(cmdBuffer)			
-			cmdBuffer = ""
+			# handle the possibility that multiple commands came through
+			commands = cmdBuffer.split('\n')
+			[cmdQueue.put(command) for command in commands[:-1]]
+			# last element of the split will either be an incomplete command or an empty string
+			cmdBuffer = commands[-1]
 
 def onExit(s):
 	s.close()


### PR DESCRIPTION
This addresses a bug related to how the python driver code parses commands received over TCP socket. If multiple messages come at once (full or partial), some messages may be dropped when processing.

Consider the string `hRQ,xxxxx\nhRQ,yyyyy\n` (handshakes used as an example -- ignore the fact that multiple handshakes may be silly). If this string is read by the TCP socket all at once (which TCP could do), `cmdQueue` gets 1 string added. This results in `sendHandshakeResponse()` being called with the array `[ 'hRQ', 'xxxxx\nhRQ', 'yyyyy\n' ]`, which clearly contains a bad `params[1]`. The second command will never be processed.

Also consider that the TCP socket first reads `hRQ,zzzzz\nhRQ,ww` then later receives `www\n`. This will result in a similar incorrect processing, where `sendHandshakeResponse()` gets `[ 'hRQ', 'zzzzz\nhRQ', 'ww' ]`. However, this will also cause `www\n` to be enqueued into `cmdQueue` which fails parsing (logging "Unable to parse command", if logging is enabled).

The above scenarios may not be encountered if commands are sent to clients slowly enough (for TCP to transmit and the client to process each command).

Furthermore, all commands will have `\n` added to the last parameter. This is unclear how bad this is, as it's unclear how many parameters are actually sent for any commands (this is client code only).

With this change:
  * Receiving multiple commands (full or partial) will enqueue each command alone, resulting in all commands being processed.
  * Partial received commands (after full ones) will remain in `cmdBuffer` to eventually be finished by reading more from the socket (just as if a partial command were received by itself).
  * No extra `\n` will be appended onto the last parameter.