### PR TITLE
Small compiler fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
 
 *.DS_Store
 BottangoNetworkedDriver/src/__pycache__/
-.vs/
-*.sln
-*.vcxproj
-*.vcxproj.filters
-BottangoArduinoDriver/__vm/
-*.esp32.bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 
 *.DS_Store
 BottangoNetworkedDriver/src/__pycache__/
+.vs/
+*.sln
+*.vcxproj
+*.vcxproj.filters
+BottangoArduinoDriver/__vm/
+*.esp32.bin

--- a/BottangoArduinoDriver/src/AbstractCommandStreamDataSource.h
+++ b/BottangoArduinoDriver/src/AbstractCommandStreamDataSource.h
@@ -4,6 +4,7 @@
 class AbstractCommandStreamDataSource
 {
 public:
+	~AbstractCommandStreamDataSource() {}
     virtual void getNextCommand(char *output, bool shouldLoop, unsigned long &msEndOfThisCommand, unsigned long &msStartOfNextCommand);
     virtual void reset();
     virtual void update(bool shouldLoop);

--- a/BottangoArduinoDriver/src/AbstractCommandStreamDataSource.h
+++ b/BottangoArduinoDriver/src/AbstractCommandStreamDataSource.h
@@ -4,7 +4,7 @@
 class AbstractCommandStreamDataSource
 {
 public:
-	~AbstractCommandStreamDataSource() {}
+	virtual ~AbstractCommandStreamDataSource() {}
     virtual void getNextCommand(char *output, bool shouldLoop, unsigned long &msEndOfThisCommand, unsigned long &msStartOfNextCommand);
     virtual void reset();
     virtual void update(bool shouldLoop);

--- a/BottangoArduinoDriver/src/BasicCommands.cpp
+++ b/BottangoArduinoDriver/src/BasicCommands.cpp
@@ -319,15 +319,15 @@ namespace BasicCommands
 
     void registerAudioEvent(char **args)
     {
-        char *identifier = args[1];
-        byte index = atoi(args[2]);
-
 #ifdef AUDIO_TRIGGER_EVENT
         // should not be hit
         Outgoing::printLine();
         Outgoing::printOutputStringFlash(F("errInvalidAudioKeyframe"));
         Outgoing::printLine();
 #elif defined(AUDIO_SD_I2S)
+		char* identifier = args[1];
+		byte index = atoi(args[2]);
+
         LOG_MKBUF
         LOG_LN(F("register audio i2s event"))
         LOG(F("    id="))

--- a/BottangoArduinoDriver/src/BottangoCore.cpp
+++ b/BottangoArduinoDriver/src/BottangoCore.cpp
@@ -522,10 +522,11 @@ namespace BottangoCore
 
     void stop()
     {
-        while (Serial.available() > 0)
-        {
-            char t = Serial.read();
-        }
+		int t;
+		while (t = Serial.available() > 0)
+		{
+			while (t--) Serial.read();
+		}
         initialized = false;
         commandInProgress = false;
         serialCommandIdx = 0;

--- a/BottangoArduinoDriver/src/BottangoCore.cpp
+++ b/BottangoArduinoDriver/src/BottangoCore.cpp
@@ -401,7 +401,6 @@ namespace BottangoCore
 
     unsigned long getMSEndTimeOfCommand(char *commandString)
     {
-        unsigned long time = Time::getCurrentTimeInMs();
         byte commandCount = 0;
         bool splitSuccess = splitIntoBuffer(commandString, commandCount);
         if (!splitSuccess)

--- a/BottangoArduinoDriver/src/BottangoCore.cpp
+++ b/BottangoArduinoDriver/src/BottangoCore.cpp
@@ -523,7 +523,7 @@ namespace BottangoCore
     void stop()
     {
 		int t;
-		while (t = Serial.available() > 0)
+		while ((t = Serial.available()) > 0)
 		{
 			while (t--) Serial.read();
 		}

--- a/BottangoArduinoDriver/src/BottangoCore.cpp
+++ b/BottangoArduinoDriver/src/BottangoCore.cpp
@@ -401,6 +401,7 @@ namespace BottangoCore
 
     unsigned long getMSEndTimeOfCommand(char *commandString)
     {
+        unsigned long time = Time::getCurrentTimeInMs();
         byte commandCount = 0;
         bool splitSuccess = splitIntoBuffer(commandString, commandCount);
         if (!splitSuccess)

--- a/BottangoArduinoDriver/src/BottangoCore.cpp
+++ b/BottangoArduinoDriver/src/BottangoCore.cpp
@@ -522,10 +522,9 @@ namespace BottangoCore
 
     void stop()
     {
-		int t;
-		while ((t = Serial.available()) > 0)
+		while (Serial.available() > 0)
 		{
-			while (t--) Serial.read();
+			Serial.read();
 		}
         initialized = false;
         commandInProgress = false;

--- a/BottangoArduinoDriver/src/PinStepperEffector.h
+++ b/BottangoArduinoDriver/src/PinStepperEffector.h
@@ -17,7 +17,7 @@ protected:
     byte pin2 = 0;
     byte pin3 = 0;
 
-    volatile byte stepLoop = 0;
+    byte stepLoop = 0;
 
 private:
     void pulse();


### PR DESCRIPTION
Fixed a few compiler warnings (see commits).
Also changed the rx-buffer clearing inside stop(). This should be a bit faster and also removes the warning for a unsuded variable 't'