### PR TITLE
Enable custom i2c pins

### DIFF
--- a/BottangoArduinoDriver/BottangoArduinoConfig.h
+++ b/BottangoArduinoDriver/BottangoArduinoConfig.h
@@ -50,6 +50,12 @@
 #define SELECT_EXPORTED_IS_LOW                     // LOW on pin selects exported. Comment out this line to choose exported on highs.
 #endif
 
+// !! i2c Pin Configuration !!
+#ifdef I2C_CUSTOM_PINS
+#define I2C_SDA 21
+#define I2C_SCL 22
+#endif
+
 // !! I2S and Audio Pins !!
 #ifdef AUDIO_SD_I2S
 #define I2S_BCLK 25                                 // bit clock line

--- a/BottangoArduinoDriver/BottangoArduinoModules.h
+++ b/BottangoArduinoDriver/BottangoArduinoModules.h
@@ -31,6 +31,11 @@
 
 // ---------------------------------- //
 
+// !!I2C!!
+// #define I2C_CUSTOM_PINS                              //uncomment this line to enable custom i2c sda & scl pins, defined in BottangoArduinoConfig.h
+
+// ---------------------------------- //
+
 // !!AUDIO!!
 // (select only 1)
 #define AUDIO_TRIGGER_EVENT                        // uncomment this line to have audio keyframes act as trigger events

--- a/BottangoArduinoDriver/src/Adafruit_PWMServoDriverContainer.cpp
+++ b/BottangoArduinoDriver/src/Adafruit_PWMServoDriverContainer.cpp
@@ -4,7 +4,12 @@ Adafruit_PwmServoDriverContainer::Adafruit_PwmServoDriverContainer(byte i2cAddre
 {
     this->i2cAddress = i2cAddress;
 #ifdef USE_ADAFRUIT_PWM_LIBRARY
-    driver = new Adafruit_PWMServoDriver(i2cAddress);
+    #ifdef I2C_CUSTOM_PINS
+        Wire.begin(I2C_SDA, I2C_SCL);
+        driver = new Adafruit_PWMServoDriver(i2cAddress, Wire);
+    #else
+        driver = new Adafruit_PWMServoDriver(i2cAddress);
+    #endif
     driver->begin();
     Wire.setClock(400000);
     driver->setPWMFreq(50);


### PR DESCRIPTION
this update adds define I2C_CUSTOM_PINS, I2C_SDA, I2C_SCL to enable custom pin to be used for i2c communication.